### PR TITLE
Workflow & scripts for scheduled release

### DIFF
--- a/.github/scripts/set-release-date.sh
+++ b/.github/scripts/set-release-date.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ ! -d $1 ]; then
+  echo "Directory not found" 1>&2
+  exit 1
+fi
+
+DATE_STR=$(TZ=UTC-9 date '+%Y-%m-%d')
+echo "Setting date to $DATE_STR..."
+
+MD_LIST=($(grep -Erl --include='*.md' '^date: *$' $1))
+
+for MD in "${MD_LIST[@]}"
+do
+  sed -i -E "s/^date: *$/date: $DATE_STR/" $MD
+  echo -n "$MD > "
+  grep -E '^date:' $MD
+done

--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -1,0 +1,70 @@
+name: Scheduled merge
+
+on:
+  workflow_dispatch:
+  schedule:
+    # JST 月,水,金 11:45 (UTC のため -9h)
+    - cron:  '45 2 * * 1,3,5'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: List pull requests
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+          const query = `query listPulls($owner: String!, $name: String!) {
+            repository(owner: $owner, name: $name) {
+              pullRequests(states: OPEN, first: 1, orderBy: {field: CREATED_AT, direction: DESC}, baseRefName: "release") {
+                totalCount
+                nodes {
+                  number
+                  title
+                  createdAt
+                  baseRefName
+                  headRefName
+                  url
+                  state
+                  isDraft
+                  merged
+                  mergeable
+                  mergeStateStatus
+                }
+              }
+            }
+          }
+          `
+          const variables = {
+            owner,
+            name: repo,
+            mediaType: {
+              previews: ["merge-info-preview"]
+            }
+          }
+          const data = await github.graphql(query, variables)
+          const { repository: { pullRequests: { nodes } } } = data
+          const pulls = nodes || []
+          console.debug(JSON.stringify(pulls, null, 2)
+          const candidates = pulls
+            .filter(pull => pull.headRefName.startsWith('post/'))
+            .filter(pull => {
+              const { number, url, headRefName, isDraft, mergeable, mergeStateStatus } = pull
+              const isCandidate = !isDraft && mergeable === 'MERGEABLE' && mergeStateStatus === 'CLEAN'
+              console.log(`#${number} ${url} ${headRefName}: ${isCandidate} (isDraft: ${isDraft}, mergeable: ${mergeable}, mergeStateStatus: ${mergeStateStatus})`)
+              return isCandidate
+            })
+          if (candidates.length > 0) {
+            const { number, url } = candidates[0]
+            console.log(`Merging #${number}...`)
+            await github.pulls.merge({
+              owner,
+              repo,
+              pull_number: number
+            })
+            console.log(`Merged #${number} (${url})`)
+          }

--- a/.github/workflows/scheduled-merge.yml
+++ b/.github/workflows/scheduled-merge.yml
@@ -17,10 +17,10 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
-          const { issue: { number: issue_number }, repo: { owner, repo } } = context;
+          const { repo: { owner, repo } } = context;
           const query = `query listPulls($owner: String!, $name: String!) {
             repository(owner: $owner, name: $name) {
-              pullRequests(states: OPEN, first: 1, orderBy: {field: CREATED_AT, direction: DESC}, baseRefName: "release") {
+              pullRequests(states: OPEN, first: 1, orderBy: {field: CREATED_AT, direction: ASC}, baseRefName: "release") {
                 totalCount
                 nodes {
                   number


### PR DESCRIPTION
@k-so16 マージ自動化のために `date:` が設定されていない記事に対して実行日の日付を設定したくて、とりあえず `date: ` を置き換えるシェルスクリプトは作ったんですが、 `date: ` がないときのことも考慮したほうがいいかと思ってます。

`date: ` がない かつ Frontmatter がある場合に title タグの下の行に `date: $DATE_STR` を追加するように修正してもらえませんか。
