### PR TITLE
期間投稿リポート

### DIFF
--- a/.github/scripts/term-summary.sh
+++ b/.github/scripts/term-summary.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ $# = 1 ]; then
+  dt=$1
+else
+  dt=`TZ=JST-9 date '+%Y-%m-%d'`
+fi
+
+echo '# date: '${dt}
+
+dt=`date --date "-1 day ${dt}" '+%Y-%m-%d'`
+year=`date --date "1 month ${dt}" '+%Y'`
+
+# 12～5 → 1 6～11 → 7
+month=$(((`date --date "${dt}" '+%-m'`/6*6+1)%12))
+
+first_day=`date --date "-1 month ${year}-${month}-02" '+%Y-%m-%d'`
+last_day=`date --date "5 month ${year}-${month}-01" '+%Y-%m-%d'`
+
+echo '# term: '${first_day} '~' ${last_day}
+
+grep -rEI '^date: ?[0-9\-]+$' --exclude-dir=.draft . | \
+  sed -r 's/\W*\/([^\/]+).+(20[0-9]{2}-[0-9]{2}-[0-9]{2})$/\2 \1/' | \
+  awk -v first="${first_day}" -v last="${last_day}" '$1 >= first && $1 <= last' | \
+  awk '{print $2}' | sort | uniq -c | sort | awk '{print $2" "$1}'

--- a/.github/scripts/term-summary.sh
+++ b/.github/scripts/term-summary.sh
@@ -17,7 +17,8 @@ last_day=`date --date "5 month ${year}-${month}-01" '+%Y-%m-%d'`
 
 echo ${first_day} '~' ${last_day}
 
-grep -rEI '^date: ?[0-9\-]+$' --exclude-dir=.draft . | \
+find . -name '*.md' -type f -not -path './.draft/*' |\
+  xargs grep -E '^date: ?[0-9\-]+$' | \
   sed -r 's/\W*\/([^\/]+).+(20[0-9]{2}-[0-9]{2}-[0-9]{2})$/\2 \1/' | \
   awk -v first="${first_day}" -v last="${last_day}" '$1 >= first && $1 <= last' | \
   awk '{print $2}' | sort | uniq -c | sort | awk '{print $2" "$1}'

--- a/.github/scripts/term-summary.sh
+++ b/.github/scripts/term-summary.sh
@@ -6,8 +6,6 @@ else
   dt=`TZ=JST-9 date '+%Y-%m-%d'`
 fi
 
-echo '# date: '${dt}
-
 dt=`date --date "-1 day ${dt}" '+%Y-%m-%d'`
 year=`date --date "1 month ${dt}" '+%Y'`
 
@@ -17,7 +15,7 @@ month=$(((`date --date "${dt}" '+%-m'`/6*6+1)%12))
 first_day=`date --date "-1 month ${year}-${month}-02" '+%Y-%m-%d'`
 last_day=`date --date "5 month ${year}-${month}-01" '+%Y-%m-%d'`
 
-echo '# term: '${first_day} '~' ${last_day}
+echo ${first_day} '~' ${last_day}
 
 grep -rEI '^date: ?[0-9\-]+$' --exclude-dir=.draft . | \
   sed -r 's/\W*\/([^\/]+).+(20[0-9]{2}-[0-9]{2}-[0-9]{2})$/\2 \1/' | \

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -1,0 +1,49 @@
+name: Report term summary
+
+on:
+  workflow_dispatch:
+  schedule:
+    # JST 月 9:00 (UTC のため -9h)
+    - cron: '0 0 * * 1'
+  push:
+    branches:
+      - term-summary
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: Release
+
+    env:
+
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Make summary
+      id: make-summary
+      run: |
+        chmod +x .github/scripts/term-summary.sh
+        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf "*"$1"* "$2"\\n"}')
+        echo "::set-output name=summary::$TEXT"
+
+    - name: Report to slack
+      uses: 8398a7/action-slack@v3
+      env:
+        SUMMARY: ${{ steps.make-summary.outputs.summary }}
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        status: custom
+        custom_payload: |
+          {
+            text: 'ブログの執筆状況を報告するよ :rola-ok:'
+            attachments: [
+              {
+                color: 'good',
+                text: `${process.env.SUMMARY}`,
+              }
+            ]
+          }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -45,7 +45,7 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: process.env.PERIOD.replace(/-/g, '/').replace('~', '～'),
+                title: process.env.PERIOD.replace(/-/g, '/').replace('~', '～'),
                 fields: process.env.SUMMARY
                   .split(';')
                   .map(x => x.split(':'))

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         chmod +x .github/scripts/term-summary.sh
         OUTPUT=$(.github/scripts/term-summary.sh)
-        TERM=$(echo ${OUTPUT} | head -n 1')
+        TERM=$(echo ${OUTPUT} | head -n 1)
         SUMMARY=$(echo ${OUTPUT} | tail -n +3 | awk '{printf $1":"$2";"}')
         echo "::set-output name=term::$TERM"
         echo "::set-output name=summary::$SUMMARY"

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     # JST 月 9:00 (UTC のため -9h)
     - cron: '0 0 * * 1'
-  push:
-    branches:
-      - term-summary
 
 jobs:
   build:

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -46,12 +46,13 @@ jobs:
               {
                 color: 'good',
                 text: process.env.TERM,
-                fields: process.env.SUMMARY.split(';')
+                fields: process.env.SUMMARY
+                  .split(';')
                   .map(x => x.split(':'))
                   .map(x => ({
                       'title': x[0],
                       'value': x[1],
-                      'short': true,
+                      'short': false,
                   })),
               },
             ]

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -26,15 +26,15 @@ jobs:
       run: |
         chmod +x .github/scripts/term-summary.sh
         OUTPUT=$(.github/scripts/term-summary.sh)
-        TERM=$(echo ${OUTPUT} | head -n 1)
-        SUMMARY=$(echo ${OUTPUT} | tail -n +3 | awk '{printf $1":"$2";"}')
-        echo "::set-output name=term::$TERM"
+        PERIOD=$(echo "${OUTPUT}" | head -n 1)
+        SUMMARY=$(echo "${OUTPUT}" | tail -n +3 | awk '{printf $1":"$2";"}')
+        echo "::set-output name=period::$PERIOD"
         echo "::set-output name=summary::$SUMMARY"
 
     - name: Report to slack
       uses: 8398a7/action-slack@v3
       env:
-        TERM: ${{ steps.make-summary.outputs.term }}
+        PERIOD: ${{ steps.make-summary.outputs.period }}
         SUMMARY: ${{ steps.make-summary.outputs.summary }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
@@ -45,14 +45,14 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: process.env.TERM,
+                text: process.env.PERIOD.replace('~', '～'),
                 fields: process.env.SUMMARY
                   .split(';')
                   .map(x => x.split(':'))
                   .map(x => ({
                       'title': x[0],
                       'value': x[1],
-                      'short': false,
+                      'short': true,
                   })),
               },
             ]

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -25,7 +25,7 @@ jobs:
       id: make-summary
       run: |
         chmod +x .github/scripts/term-summary.sh
-        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf "*"$1"*: `"$2"`\;"}')
+        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf $1":"$2";"}')
         echo "::set-output name=summary::$TEXT"
 
     - name: Report to slack
@@ -38,10 +38,27 @@ jobs:
         custom_payload: |
           {
             text: 'ブログの執筆状況を報告するよ :rola-ok:',
+            blocks: [
+              {
+                'type': 'section',
+                'text': {
+                  'type': 'mrkdwn',
+                  'text': `${process.env.SUMMARY.replace(/;/g, '\n')}`
+                }
+              },
+            ]
             attachments: [
               {
                 color: 'good',
-                text: `${process.env.SUMMARY.replace(/;/g, '\n')}`,
-              }
+                text: `hogehoge`,
+                fields: process.env.SUMMARY.split(';')
+                  .map(x => x.split(':'))
+                  .map(x => ({
+                      'title': x[0],
+                      'value': x[1],
+                      'short': false,
+                  })),
+              },
+              
             ]
           }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -46,7 +46,7 @@ jobs:
                   'text': `${process.env.SUMMARY.replace(/;/g, '\n')}`
                 }
               },
-            ]
+            ],
             attachments: [
               {
                 color: 'good',

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -41,7 +41,7 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: `${process.env.SUMMARY.replace('\\n', '\n')}`,
+                text: `${process.env.SUMMARY.replace(/\\n/g, '\n')}`,
               }
             ]
           }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -25,7 +25,7 @@ jobs:
       id: make-summary
       run: |
         chmod +x .github/scripts/term-summary.sh
-        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf "*"$1"* "$2"\\n"}')
+        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf "*"$1"*: `"$2"`\;"}')
         echo "::set-output name=summary::$TEXT"
 
     - name: Report to slack
@@ -41,7 +41,7 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: `${process.env.SUMMARY.replace(/\\n/g, '\n')}`,
+                text: `${process.env.SUMMARY.replace(/;/g, '\n')}`,
               }
             ]
           }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -41,7 +41,7 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: `${process.env.SUMMARY}`,
+                text: `${process.env.SUMMARY.replace('\\n', '\n')}`,
               }
             ]
           }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -37,7 +37,7 @@ jobs:
         status: custom
         custom_payload: |
           {
-            text: 'ブログの執筆状況を報告するよ :rola-ok:'
+            text: 'ブログの執筆状況を報告するよ :rola-ok:',
             attachments: [
               {
                 color: 'good',

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -25,12 +25,16 @@ jobs:
       id: make-summary
       run: |
         chmod +x .github/scripts/term-summary.sh
-        TEXT=$(.github/scripts/term-summary.sh | grep -v '^#' | awk '{printf $1":"$2";"}')
-        echo "::set-output name=summary::$TEXT"
+        OUTPUT=$(.github/scripts/term-summary.sh)
+        TERM=$(echo ${OUTPUT} | head -n 1')
+        SUMMARY=$(echo ${OUTPUT} | tail -n +3 | awk '{printf $1":"$2";"}')
+        echo "::set-output name=term::$TERM"
+        echo "::set-output name=summary::$SUMMARY"
 
     - name: Report to slack
       uses: 8398a7/action-slack@v3
       env:
+        TERM: ${{ steps.make-summary.outputs.term }}
         SUMMARY: ${{ steps.make-summary.outputs.summary }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
@@ -38,27 +42,17 @@ jobs:
         custom_payload: |
           {
             text: 'ブログの執筆状況を報告するよ :rola-ok:',
-            blocks: [
-              {
-                'type': 'section',
-                'text': {
-                  'type': 'mrkdwn',
-                  'text': `${process.env.SUMMARY.replace(/;/g, '\n')}`
-                }
-              },
-            ],
             attachments: [
               {
                 color: 'good',
-                text: `hogehoge`,
+                text: process.env.TERM,
                 fields: process.env.SUMMARY.split(';')
                   .map(x => x.split(':'))
                   .map(x => ({
                       'title': x[0],
                       'value': x[1],
-                      'short': false,
+                      'short': true,
                   })),
               },
-              
             ]
           }

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     # JST 月 9:00 (UTC のため -9h)
     - cron: '0 0 * * 1'
+  push:
+    branches:
+      - term-summary
 
 jobs:
   build:
@@ -19,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Make summary
-      id: make-summary
+      id: make-summary-1
       run: |
         chmod +x .github/scripts/term-summary.sh
         OUTPUT=$(.github/scripts/term-summary.sh)
@@ -28,11 +31,23 @@ jobs:
         echo "::set-output name=period::$PERIOD"
         echo "::set-output name=summary::$SUMMARY"
 
+    - name: Make summary
+      id: make-summary-2
+      run: |
+        chmod +x .github/scripts/term-summary.sh
+        OUTPUT=$(.github/scripts/term-summary.sh $(date --date '-6 months' +%Y-%m-%d))
+        PERIOD=$(echo "${OUTPUT}" | head -n 1)
+        SUMMARY=$(echo "${OUTPUT}" | tail -n +3 | awk '{printf $1":"$2";"}')
+        echo "::set-output name=period::$PERIOD"
+        echo "::set-output name=summary::$SUMMARY"
+
     - name: Report to slack
       uses: 8398a7/action-slack@v3
       env:
-        PERIOD: ${{ steps.make-summary.outputs.period }}
-        SUMMARY: ${{ steps.make-summary.outputs.summary }}
+        PERIOD1: ${{ steps.make-summary-1.outputs.period }}
+        SUMMARY1: ${{ steps.make-summary-1.outputs.summary }}
+        PERIOD2: ${{ steps.make-summary-2.outputs.period }}
+        SUMMARY2: ${{ steps.make-summary-2.outputs.summary }}
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
         status: custom
@@ -41,9 +56,21 @@ jobs:
             text: 'ブログの執筆状況を報告するよ :rola-ok:',
             attachments: [
               {
+                color: '#1e90ff',
+                title: process.env.PERIOD2.replace(/-/g, '/').replace('~', '～'),
+                fields: process.env.SUMMARY2
+                  .split(';')
+                  .map(x => x.split(':'))
+                  .map(x => ({
+                      'title': x[0],
+                      'value': x[1],
+                      'short': true,
+                  })),
+              },
+              {
                 color: 'good',
-                title: process.env.PERIOD.replace(/-/g, '/').replace('~', '～'),
-                fields: process.env.SUMMARY
+                title: process.env.PERIOD1.replace(/-/g, '/').replace('~', '～'),
+                fields: process.env.SUMMARY1
                   .split(';')
                   .map(x => x.split(':'))
                   .map(x => ({

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -45,7 +45,7 @@ jobs:
             attachments: [
               {
                 color: 'good',
-                text: process.env.PERIOD.replace('~', '～'),
+                text: process.env.PERIOD.replace(/-/g, '/').replace('~', '～'),
                 fields: process.env.SUMMARY
                   .split(';')
                   .map(x => x.split(':'))

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -16,8 +16,6 @@ jobs:
     environment:
       name: Release
 
-    env:
-
     steps:
 
     - name: Checkout

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -5,9 +5,6 @@ on:
   schedule:
     # JST 月 9:00 (UTC のため -9h)
     - cron: '0 0 * * 1'
-  push:
-    branches:
-      - term-summary
 
 jobs:
   build:
@@ -21,7 +18,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Make summary
+    - name: Make summary (Current term)
       id: make-summary-1
       run: |
         chmod +x .github/scripts/term-summary.sh
@@ -31,7 +28,7 @@ jobs:
         echo "::set-output name=period::$PERIOD"
         echo "::set-output name=summary::$SUMMARY"
 
-    - name: Make summary
+    - name: Make summary (Previous term)
       id: make-summary-2
       run: |
         chmod +x .github/scripts/term-summary.sh


### PR DESCRIPTION
Slack に期間リポートが届くようにしました。

![image](https://user-images.githubusercontent.com/13431810/133375035-20ca08e8-2286-4691-8994-f229b307a3ce.png)

シェルスクリプトで 各 Markdown の date frontmatter を取得して、当該期間分を集計し、 Slack message の形に整形して投げているだけです。

一応、現期間と半期前もリポートするようにしました。

毎週月曜日9時に動くよう cron にしました。