### PR TITLE
リリース関連ワークフロー修正

### DIFF
--- a/.github/workflows/release-01-cron.yml
+++ b/.github/workflows/release-01-cron.yml
@@ -1,7 +1,9 @@
-name: Scheduled merge
+# 定期リリース
+name: Release Scheduled merge
 
 on:
   workflow_dispatch:
+
   schedule:
     # JST 月,水,金 11:45 (UTC のため -9h)
     - cron:  '45 2 * * 1,3,5'
@@ -10,12 +12,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    environment:
+      name: Release
+
     steps:
 
     - name: List pull requests
       uses: actions/github-script@v4
       with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+        github-token: ${{ secrets.CI_GITHUB_TOKEN }}
         script: |
           const { repo: { owner, repo } } = context;
           const query = `query listPulls($owner: String!, $name: String!) {
@@ -68,5 +73,6 @@ jobs:
             })
             console.log(`Merged #${number} (${url})`)
           } else {
-            console.log(`No pull request to be merged`)
+            // set failed when no pull request merged
+            core.setFailed(`No pull request to be merged`);
           }

--- a/.github/workflows/release-02-preprocess.yml
+++ b/.github/workflows/release-02-preprocess.yml
@@ -1,44 +1,65 @@
-name: Optimize images
+# release ブランチのデプロイの前に呼び出されるワークフロー
+# - リリース日設定
+# - 画像最適化
+name: Release Pre-process
 
 on:
+  # release ブランチへのプルリクエストが閉じられたときに実行
+  # ※ PR にコメントするため PR 起点とする
+  # ※ 別のワークフローからマージする場合は Actions の GITHUB_TOKEN では後続のワークフローが実行されないため、別途発行した Personal Access Token で実行すること
+  # ※ 「マージ時」に限定する場合は job や steps で if: github.event.pull_request.merged == true をチェックすること
   pull_request:
     branches:
       - release
     types: [closed]
 
 jobs:
-  build:
+
+  process:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true
 
+    environment:
+      name: Release
+
     steps:
 
+      # Git 初期化 & 必要なファイルのチェックアウト
+      # 直前のコミットとの差分ファイルと処理に必要なファイルのみを sparse-checkout
       - name: Checkout content
         run: |
           BRANCH_NAME=${GITHUB_BASE_REF#refs/heads/}
           echo "BRANCH_NAME: ${BRANCH_NAME} GITHUB_SHA: ${GITHUB_SHA}"
           git init -q
-          git remote add origin https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git
+          git remote add origin https://${{secrets.CI_GITHUB_USER}}:${{secrets.CI_GITHUB_TOKEN}}@github.com/${{github.repository}}.git
           git fetch --depth 2
           git config core.sparsecheckout true
           echo .gitignore >> .git/info/sparse-checkout
           echo .github >> .git/info/sparse-checkout
           echo package.json >> .git/info/sparse-checkout
           echo package-lock.json >> .git/info/sparse-checkout
-          git -c core.quotepath=false diff ${GITHUB_SHA}^ ${GITHUB_SHA} --name-only | grep -rEI '\.(jpg|png|gif|svg)$' - >> .git/info/sparse-checkout
+          git -c core.quotepath=false diff ${GITHUB_SHA}^ ${GITHUB_SHA} --name-only >> .git/info/sparse-checkout
           cat .git/info/sparse-checkout
           git checkout -q ${BRANCH_NAME}
 
+      # リリース日の設定
+      - name: Set release date
+        id: set-release-date
+        run: chmod +x .github/scripts/set-release-date.sh && .github/scripts/set-release-date.sh
+
+      # Node & npm 初期化
       - name: Node
         uses: actions/setup-node@v2
         with:
           node-version: '14'
           cache: npm
 
+      # npm install
       - name: npm install
         run: npm ci
 
-      - name: Execute optimization
+      # 画像最適化
+      - name: Execute image-optimization
         id: optimization
         run: |
           SECONDS=0
@@ -48,9 +69,11 @@ jobs:
           echo "::set-output name=result::$RESULT"
           echo "::set-output name=elapsed::$SECONDS"
 
+      # コミットプッシュ
       - name: Commit & push
         id: commit
         run: |
+          git remote set-url origin https://me:${CI_GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add -u
@@ -59,6 +82,7 @@ jobs:
           COMMIT_HASH=$(git rev-parse HEAD)
           echo "::set-output name=hash::$COMMIT_HASH"
 
+      # Pull request に画像最適化の結果をコメント
       - name: Comment to PR
         uses: actions/github-script@0.3.0
         with:

--- a/.github/workflows/release-03-deploy.yml
+++ b/.github/workflows/release-03-deploy.yml
@@ -1,14 +1,21 @@
-name: Deploy release
+# release ブランチを本番環境にデプロイ
+name: Release Deploy
 
 on:
-  push:
-    branches:
-      - release
+  # 手動実行時
+  workflow_dispatch:
+
+  # デプロイ前処理の実行後
+  workflow_run:
+    workflows:
+      - Release Pre-process
+    types: [completed]
 
 jobs:
-  build:
+
+  deploy:
     runs-on: ubuntu-latest
-    
+
     environment:
       name: Release
 

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -24,7 +24,7 @@ jobs:
         chmod +x .github/scripts/term-summary.sh
         OUTPUT=$(.github/scripts/term-summary.sh)
         PERIOD=$(echo "${OUTPUT}" | head -n 1)
-        SUMMARY=$(echo "${OUTPUT}" | tail -n +3 | awk '{printf $1":"$2";"}')
+        SUMMARY=$(echo "${OUTPUT}" | tail -n +2 | awk '{printf $1":"$2";"}')
         echo "::set-output name=period::$PERIOD"
         echo "::set-output name=summary::$SUMMARY"
 
@@ -34,7 +34,7 @@ jobs:
         chmod +x .github/scripts/term-summary.sh
         OUTPUT=$(.github/scripts/term-summary.sh $(date --date '-6 months' +%Y-%m-%d))
         PERIOD=$(echo "${OUTPUT}" | head -n 1)
-        SUMMARY=$(echo "${OUTPUT}" | tail -n +3 | awk '{printf $1":"$2";"}')
+        SUMMARY=$(echo "${OUTPUT}" | tail -n +2 | awk '{printf $1":"$2";"}')
         echo "::set-output name=period::$PERIOD"
         echo "::set-output name=summary::$SUMMARY"
 

--- a/linkohta/2021/ruby-on-rails7/index.md
+++ b/linkohta/2021/ruby-on-rails7/index.md
@@ -1,6 +1,6 @@
 ---
 title: 【2021年から Ruby on Rails をはじめる人向け】 Ruby on Rails 6 入門 Part 7 ～ Rails でバリデーションチェックを自動で行う方法～
-date: 
+date: 2021-10-08
 author: linkohta
 tags: [Ruby on Rails, Web]
 ---


### PR DESCRIPTION
リリース関連のワークフローを修正しました。

「ワークフローから Pull request がマージされても、別のワークフローがキックされない」という仕様があり、「release ブランチにプッシュされたとき」というトリガーにしていたワークフローが動作しないことがわかりました。

上記仕様は Actions の中で利用できる `GITHUB_TOKEN` を利用する場合のみで、マージするときに別途ユーザーで発行した Personal access token を使うと、別のワークフローもキックされるらしいので、定期リリース用のワークフローでは CI ユーザーの token を使うようにしました。

これからはじまって下記3つのワークフローが順番に実行されるように作っています。

- `.github/workflows/release-01-cron.yml` : cron による定期実行
- `.github/workflows/release-02-preprocess.yml` : release ブランチへの PR マージで実行
- `.github/workflows/release-03-deploy.yml` : 02 の完了後に実行

マージしてからでないと動くかどうか不明なので、ざっと確認してもらったら承認していただけますか。

-  - -

ついでに、先日マージした太田君の記事に date がはまっていないので、修正しました。

 - - -

`.github/workflows/term-summary.yml` は記事数サマリーの無視する行数を間違えていたので修正しました。