### PR TITLE
リリース日設定スクリプトを改良

### DIFF
--- a/.github/scripts/set-release-date.sh
+++ b/.github/scripts/set-release-date.sh
@@ -8,7 +8,8 @@ fi
 DATE_STR=$(TZ=UTC-9 date '+%Y-%m-%d')
 echo "Setting date to $DATE_STR..."
 
-MD_LIST=($(grep -Erl --include='*.md' '^date: *$' $1))
+# *.md で値のない date: を含むファイル
+MD_LIST=($(grep -Erl --include='*.md' --exclude-dir='node_modules' --exclude='README.md' '^date: *$' $1))
 
 for MD in "${MD_LIST[@]}"
 do
@@ -16,3 +17,18 @@ do
   echo -n "$MD > "
   grep -E '^date:' $MD
 done
+
+# *.md で "date:"" 行のないファイル
+NO_DATE_MD_LIST=($(grep -ErL --include='*.md' --exclude-dir='node_modules' --exclude='README.md' '^date:' $1))
+
+for MD in "${NO_DATE_MD_LIST[@]}"
+do
+  # "title:" が含まれているファイルのみ
+  if grep -q '^title:' $MD; then
+    # "title:" 行の下に追加
+    sed -i -e "/^title:/a date: $DATE_STR" $MD
+    echo -n "$MD > "
+    grep -E '^date:' $MD
+  fi
+done
+


### PR DESCRIPTION
リリース日設定スクリプトで `date: ` の行がなくても `title: ` 行があれば直下に追加するようにしました。
基本的には GitHub Actions でマージ後に実行されるものなのでユーザーが叩く必要はないですが、念のため動作確認してもらえると助かります。

確認お願いします。