### PR TITLE
[修正] .NET Core + WPF における SecureString と PasswordBox の扱い

### DIFF
--- a/kenzauros/2020/passwordbox-and-securepassword-in-dotnet-core-with-wpf/index.md
+++ b/kenzauros/2020/passwordbox-and-securepassword-in-dotnet-core-with-wpf/index.md
@@ -54,7 +54,7 @@ unmanaged な配列を確保して暗号化して不要になったら解放し�
 
 が、プレーンテキストで取得する Password プロパティというバックドアまで存在するので、結局ザルでした。
 
-しかもこれらのプロパティ、またもセキュリティの観点から**依存関係プロパティとしては実装されておらず、バインディングできないのでここだけ　MVVM 的に実装できない**、という問題もありました。
+しかもこれらのプロパティ、またもセキュリティの観点から**依存関係プロパティとしては実装されておらず、バインディングできないのでここだけ MVVM 的に実装できない**、という問題もありました。
 
 これに対しては先人がヘルパーやビヘイビアを考案しておられるので、これを利用できます。
 
@@ -212,11 +212,23 @@ internal class PasswordBoxHelper : DependencyObject
 ```xml
 <PasswordBox
     PasswordChar="*"
+    helpers:PasswordBoxHelper.IsAttached="True"
     helpers:PasswordBoxHelper.Password="{Binding PasswordInViewModel}"
     />
 ```
 
 すっきりしていいですね。
+
+<ins>
+
+2022/6/1 追記
+
+`IsAttached` を明示的に設定しておかないとバインディングしたパスワードが空文字のときに下記の現象となり、入力値が VM に反映されません。
+（`PasswordProperty_Changed` が発生せず、 `PasswordBox_PasswordChanged` ハンドラも設定されないため）
+
+このヘルパーを使用する場合は `IsAttached` を明示的に `True` にしておきましょう。
+
+</ins>
 
 
 ## あとがき

--- a/kenzauros/2020/passwordbox-and-securepassword-in-dotnet-core-with-wpf/index.md
+++ b/kenzauros/2020/passwordbox-and-securepassword-in-dotnet-core-with-wpf/index.md
@@ -223,7 +223,7 @@ internal class PasswordBoxHelper : DependencyObject
 
 2022/6/1 追記
 
-`IsAttached` を明示的に設定しておかないとバインディングしたパスワードが空文字のときに下記の現象となり、入力値が VM に反映されません。
+`IsAttached` を明示的に設定しておかないとバインディングしたパスワードが空文字のときに、入力値が VM に反映されないことがあります。
 （`PasswordProperty_Changed` が発生せず、 `PasswordBox_PasswordChanged` ハンドラも設定されないため）
 
 このヘルパーを使用する場合は `IsAttached` を明示的に `True` にしておきましょう。


### PR DESCRIPTION
開発者ツールの開発中に動作しない場合があることがわかりましたので、記事に追記しました。