### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
     - name: Checkout generator
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ secrets.GENERATOR_BRANCH }}
         repository: mseninc/blog-gatsby
@@ -47,7 +47,7 @@ jobs:
     - name: Caching node_modules
       id: cache-node-modules
       if: env.NO_CACHE != 'true'
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-blog-preview-node_modules-${{ hashFiles('package-lock.json') }}
@@ -55,9 +55,9 @@ jobs:
     - run: ls -la
 
     - name: Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: 16
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -36,13 +36,13 @@ jobs:
         echo URL_LIST=${URL_LIST} >> $GITHUB_ENV
 
     - name: Comment to PR
-      uses: actions/github-script@0.3.0
+      uses: actions/github-script@v6
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const { issue: { number: issue_number }, repo: { owner, repo } } = context;
           const urlList = '${{ env.URL_LIST }}'.split(',').filter(n => n).map(x => `- ${x}`).join('\n');
           if (urlList) {
-            github.issues.createComment({ issue_number, owner, repo, body: `Preview URL:\n${urlList}` });
+            github.rest.issues.createComment({ issue_number, owner, repo, body: `Preview URL:\n${urlList}` });
           }
 

--- a/.github/workflows/release-01-cron.yml
+++ b/.github/workflows/release-01-cron.yml
@@ -18,8 +18,9 @@ jobs:
     steps:
 
     - name: List pull requests
-      uses: actions/github-script@v4
+      uses: actions/github-script@v6
       with:
+        retries: 3
         github-token: ${{ secrets.CI_GITHUB_TOKEN }}
         script: |
           const { repo: { owner, repo } } = context;
@@ -66,7 +67,7 @@ jobs:
           if (candidates.length > 0) {
             const { number, url } = candidates[0]
             console.log(`Merging #${number}...`)
-            await github.pulls.merge({
+            await github.rest.pulls.merge({
               owner,
               repo,
               pull_number: number

--- a/.github/workflows/release-02-preprocess.yml
+++ b/.github/workflows/release-02-preprocess.yml
@@ -69,9 +69,9 @@ jobs:
 
       # Node & npm 初期化
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
           cache: npm
 
       # npm install
@@ -86,8 +86,8 @@ jobs:
           RESULT=$(node .github/scripts/optimize-images.js . --no-backup)
           echo ${RESULT}
           RESULT="${RESULT//$'\n'/\\n}"
-          echo "::set-output name=result::$RESULT"
-          echo "::set-output name=elapsed::$SECONDS"
+          echo "result=$RESULT" >> $GITHUB_OUTPUT
+          echo "elapsed=$SECONDS" >> $GITHUB_OUTPUT
 
       # コミットプッシュ
       - name: Commit & push
@@ -99,11 +99,11 @@ jobs:
           git commit -m "Release pre-process"
           git push origin ${GIT_BRANCH}
           COMMIT_HASH=$(git rev-parse HEAD)
-          echo "::set-output name=hash::$COMMIT_HASH"
+          echo "hash=$COMMIT_HASH" >> $GITHUB_OUTPUT
 
       # Pull request に画像最適化の結果をコメント
       - name: Comment to PR
-        uses: actions/github-script@0.3.0
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -124,5 +124,5 @@ jobs:
                   return `[${fileName}](${baseUrl}${relPath})`
                 })
               const body = `### Image optimization\ncommit: ${commitHash} elapsed: ${elapsed}\n${resultText}`
-              github.issues.createComment({ issue_number, owner, repo, body })
+              github.rest.issues.createComment({ issue_number, owner, repo, body })
             }

--- a/.github/workflows/release-03-deploy.yml
+++ b/.github/workflows/release-03-deploy.yml
@@ -34,19 +34,19 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ secrets.GENERATOR_BRANCH }}
         repository: mseninc/blog-gatsby
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: content
         
     - name: Caching Gatsby
       id: gatsby-cache-build
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           public
@@ -56,9 +56,9 @@ jobs:
     - run: ls -la
 
     - name: Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version: 16
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,9 +31,9 @@ jobs:
           git checkout -q origin/${BRANCH_NAME}
 
       - name: Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
           cache: npm
 
       - name: npm install

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Make summary (Current term)
       id: make-summary-1
@@ -25,8 +25,8 @@ jobs:
         OUTPUT=$(.github/scripts/term-summary.sh)
         PERIOD=$(echo "${OUTPUT}" | head -n 1)
         SUMMARY=$(echo "${OUTPUT}" | tail -n +2 | awk '{printf $1":"$2";"}')
-        echo "::set-output name=period::$PERIOD"
-        echo "::set-output name=summary::$SUMMARY"
+        echo "period=$PERIOD" >> $GITHUB_OUTPUT
+        echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
 
     - name: Make summary (Previous term)
       id: make-summary-2
@@ -35,8 +35,8 @@ jobs:
         OUTPUT=$(.github/scripts/term-summary.sh $(date --date '-6 months' +%Y-%m-%d))
         PERIOD=$(echo "${OUTPUT}" | head -n 1)
         SUMMARY=$(echo "${OUTPUT}" | tail -n +2 | awk '{printf $1":"$2";"}')
-        echo "::set-output name=period::$PERIOD"
-        echo "::set-output name=summary::$SUMMARY"
+        echo "period=$PERIOD" >> $GITHUB_OUTPUT
+        echo "summary=$SUMMARY" >> $GITHUB_OUTPUT
 
     - name: Report to slack
       uses: 8398a7/action-slack@v3


### PR DESCRIPTION
ワークフローで警告がでていたため、 Node.js 12 を使っている部分を Node.js 16 に更新、 `set-output` も使えなくなるそうなので修正しました。

- [GitHub Actions: All Actions will begin running on Node16 instead of Node12 | GitHub Changelog](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)
- [GitHub Actions: Deprecating save-state and set-output commands | GitHub Changelog](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

- - -

- actions/github-script を使っている部分は v6 に (v5 までは内部的に Node.js 12)
    - [actions/github-script: Write workflows scripting the GitHub API in JavaScript](https://github.com/actions/github-script)
    - REST API の `github.****` は `github.rest.****` に書き換え
- acitons/cache や actions/checkout は v3 に
    - [actions/cache: Cache dependencies and build outputs in GitHub Actions](https://github.com/actions/cache)
    - [actions/checkout: Action for checking out a repo](https://github.com/actions/checkout)
- actions/setup-node は v3 にあげた上で、 `node-version` を 16 に
    - [actions/setup-node: Set up your GitHub Actions workflow with a specific version of node.js](https://github.com/actions/setup-node)