### PR TITLE
change npm ci to npm install

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true' # https://github.com/actions/cache#Skipping-steps-based-on-cache-hit
-      run: npm ci
+      run: npm install --production
 
     - name: Build
       run: node_modules/.bin/gatsby build --verbose


### PR DESCRIPTION
workflow の node バージョンを 16 にあげたことで、 npm ci が動作していないため、 npm install に変更してみます。

![image](https://user-images.githubusercontent.com/13431810/200442698-f37fb4ab-0aca-420d-8e28-2746fd3e7e30.png)

```
npm ci
npm ERR! code EUSAGE
npm ERR! 
npm ERR! `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
```