### PR TITLE
Replace npm ci with npm install

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -62,7 +62,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.cache-node-modules.outputs.cache-hit != 'true' # https://github.com/actions/cache#Skipping-steps-based-on-cache-hit
-      run: npm install --production
+      run: npm install --omit=dev
 
     - name: Build
       run: node_modules/.bin/gatsby build --verbose

--- a/.github/workflows/release-02-preprocess.yml
+++ b/.github/workflows/release-02-preprocess.yml
@@ -76,7 +76,7 @@ jobs:
 
       # npm install
       - name: npm install
-        run: npm ci
+        run: npm install --omit=dev
 
       # 画像最適化
       - name: Execute image-optimization

--- a/.github/workflows/release-03-deploy.yml
+++ b/.github/workflows/release-03-deploy.yml
@@ -62,7 +62,7 @@ jobs:
         cache: npm
 
     - name: Install dependencies
-      run: npm ci
+      run: npm install --omit=dev
 
     - name: Build
       run: node_modules/.bin/gatsby build --verbose

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -37,7 +37,7 @@ jobs:
           cache: npm
 
       - name: npm install
-        run: npm ci
+        run: npm install --omit=dev
 
       - name: Setup reviewdog
         uses: reviewdog/action-setup@v1


### PR DESCRIPTION
プレビューと同じく本番側も npm ci のせいでデプロイができていなかったため、修正しました。

related #153 

※ついでに `--production` が非推奨なようなので `--omit=dev` に変更しました

```
npm WARN config production Use `--omit=dev` instead.
```