### PR TITLE
[GitHub Actions Workflow] Update GitHub actions-related packages

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
 
     - name: Checkout generator
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ secrets.GENERATOR_BRANCH }}
         repository: mseninc/blog-gatsby
@@ -47,7 +47,7 @@ jobs:
     - name: Caching node_modules
       id: cache-node-modules
       if: env.NO_CACHE != 'true'
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: node_modules
         key: ${{ runner.os }}-blog-preview-node_modules-${{ hashFiles('package-lock.json') }}
@@ -55,7 +55,7 @@ jobs:
     - run: ls -la
 
     - name: Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: npm

--- a/.github/workflows/preview-url.yml
+++ b/.github/workflows/preview-url.yml
@@ -36,7 +36,7 @@ jobs:
         echo URL_LIST=${URL_LIST} >> $GITHUB_ENV
 
     - name: Comment to PR
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |

--- a/.github/workflows/release-01-cron.yml
+++ b/.github/workflows/release-01-cron.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
 
     - name: List pull requests
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         retries: 3
         github-token: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/release-02-preprocess.yml
+++ b/.github/workflows/release-02-preprocess.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       # npm install

--- a/.github/workflows/release-02-preprocess.yml
+++ b/.github/workflows/release-02-preprocess.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Node & npm 初期化
       - name: Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: npm
@@ -103,7 +103,7 @@ jobs:
 
       # Pull request に画像最適化の結果をコメント
       - name: Comment to PR
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release-03-deploy.yml
+++ b/.github/workflows/release-03-deploy.yml
@@ -57,19 +57,19 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         ref: ${{ github.event.inputs.generator_branch || secrets.GENERATOR_BRANCH }}
         repository: mseninc/blog-gatsby
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: content
         
     - name: Caching Gatsby
       id: gatsby-cache-build
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           public
@@ -79,7 +79,7 @@ jobs:
     - run: ls -la
 
     - name: Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: npm

--- a/.github/workflows/release-03-deploy.yml
+++ b/.github/workflows/release-03-deploy.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Node
       uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: 20
         cache: npm
 
     - name: Install dependencies

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,9 +31,9 @@ jobs:
           git checkout -q origin/${BRANCH_NAME}
 
       - name: Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
 
       - name: npm install

--- a/.github/workflows/term-summary.yml
+++ b/.github/workflows/term-summary.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Make summary (Current term)
       id: make-summary-1


### PR DESCRIPTION
- issue #318 

This PR updates packages of files for GitHub Actions.

Currently I updated the versions of the following files. I checked if the syntax from previous version has changed. It seems the syntax is the same

```
actions/checkout@v3 ➞　v4
actions/cache@v3 ➞　v4
actions/setup-node@v3 ➞　v4
github-script@v6 ➞　v7
```

I have two questions. 
Should I run the GitHub Actions for testing? I am not sure if I can test to run a deployment.
Should I change node-version from 18 to 20, for example?  It seems the deploy destination is a AWS server and I guess the server should support it as well.