### PR TITLE
Add workflow template for Facebook posts

### DIFF
--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -28,12 +28,9 @@ jobs:
             
             const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.BLOG_URL }}';
             
-            fetch(rssUrl)
-            .then((response) => {
-              const data = response.json()
-              fs.writeFileSync('${{ env.RSS_FILENAME }}', JSON.stringify(data.items));
-            })
-            ;
+            await fetch(rssUrl);
+            const data = await response.json();
+            fs.writeFileSync('${{ env.RSS_FILENAME }}', JSON.stringify(data.items));
         
       - name: Caching Hash
         id: blog-posts-cache

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,7 +80,7 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json
           echo $token
-          id_json=$(curl -H 'Authorization: Bearer ${token}' -X GET "https://graph.facebook.com/msenjp?fields=id")
+          id_json=$(curl -H 'Authorization: Bearer ${token}' -X GET "https://graph.facebook.com/v19.0/msenjp?fields=id")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
             json=$(curl -X POST \
               -d "url=https://msen.jp/img/logo.png" \
-              -d "published=true" \
+              -d "published=false" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")
               photo_id=$(echo $json | jq -r '.id')

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - release
+      - 317-add-workflow-for-facebook-post
 
 jobs:
   release_facebook:

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ env.FACEBOOK_USER_ACCESS_TOKEN }}")            
           token=$(echo $json | jq -r '.data[].access_token')
+          echo "::add-mask::$token"
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook (If published is 'true', the photo will be published on the page's timeline.)

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -47,8 +47,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: |
-            public
-            .cache
+            ${{ env.RSS_FILENAME }}
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -51,7 +51,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -73,7 +73,7 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook page access token
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
@@ -81,7 +81,7 @@ jobs:
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
             json=$(curl -X POST \
@@ -93,7 +93,7 @@ jobs:
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
       - name: Post to Facebook
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
               -d "message=" \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .cache
-          key: blog-post-${{ hashFiles(env.RSS_FILE_PATH) }}          
+          key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         name: Get latest posts
@@ -46,7 +46,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const data = fs.readfilesync('${{ env.RSS_FILENAME }}');
+            const data = fs.readFileSync('${{ env.RSS_FILENAME }}');
             const items = JSON.parse(data)
 
             let date
@@ -65,14 +65,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const fs = require('fs');
-            const data = fs.readfilesync(outputFile, data);
-
             const { exec } = require('child_process');
             exec('
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
-              -d "published=false" \
+              -d "published=true" \
               -d "access_token=${{ secrets.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}" \
               "https://graph.facebook.com/me/photos"                
             , (error, stdout, stderr) => {

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -69,10 +69,11 @@ jobs:
       - name: Get Facebook access token
         id: token
         run: |
-          echo 'token=$(curl -X GET "https://graph.facebook.com/oauth/access_token
+          token=$(curl -X GET "https://graph.facebook.com/oauth/access_token
             ?client_id=${{ vars.FACEBOOK_APP_ID }}
             &client_secret=${{ secrets.FACEBOOK_APP_SECRET }}
-            &grant_type=client_credentials")' >> $GITHUB_OUTPUT
+            &grant_type=client_credentials")
+          echo "token=${token}" >> $GITHUB_OUTPUT
 
       - name: Post data to Facebook
         run: |

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -86,5 +86,5 @@ jobs:
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              "https://graph.facebook.com/v19.0/${{ env.PAGE_ID }}/photos" \
-              -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' \
+              -d "access_token=${{ secrets.FACEBOOK_PAGE_ACCESS_TOKEN }}" \
+              "https://graph.facebook.com/v19.0/${{ env.PAGE_ID }}/photos" 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -1,6 +1,10 @@
 name: Release Facebook
 
 on:
+  schedule:
+    # Run every day at 4:00 UTC (1:00 PM JST)
+    - cron: "0 4 * * *" 
+
   workflow_dispatch:
     inputs:
       page_id:
@@ -16,10 +20,6 @@ on:
         description: 'User access token to access Facebook'
         required: false
   
-  push:
-    branches:
-      - release
-
 jobs:
   release_facebook:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,7 +80,8 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json
           echo $token
-          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id&access_token=${token}")
+          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id"\
+          -H 'Authorization: Bearer ${{ steps.token.outputs.token }}')
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -84,5 +84,4 @@ jobs:
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              -d "access_token=${{ steps.token.outputs.token }}" \
-              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos"
+              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos?access_token=${{ steps.token.outputs.token }}"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -76,7 +76,7 @@ jobs:
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
-          json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}"            
+          json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -84,4 +84,5 @@ jobs:
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos?access_token=${{ steps.token.outputs.token }}"
+              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos" \
+              -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -22,7 +22,7 @@ jobs:
       RSS_URL: ${{ vars.RSS_FEED_URL }}
       RSS_FILENAME: rss.json
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
-      PAGE_ID: ${{ github.event.inputs.page_id || vars.FACEBOOK_PAGE_ID }}
+      PAGE_ID: ${{ vars.FACEBOOK_PAGE_ID }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -79,4 +79,4 @@ jobs:
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
               -d "access_token=${{ secrets.FACEBOOK_PAGE_ACCESS_TOKEN }}" \
-              "https://graph.facebook.com/v19.0/${{ env.PAGE_ID }}/photos" 
+              "https://graph.facebook.com/${{ env.PAGE_ID }}/photos" 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -85,7 +85,7 @@ jobs:
         id: photo_upload
         run: |
             json=$(curl -X POST \
-              -d "url=${{ steps.latest-data.outputs.result }}" \
+              -d "url=https://msen.jp/img/logo.png" \
               -d "published=true" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -71,5 +71,4 @@ jobs:
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              -d "access_token=${{ vars.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}" \
-              "https://graph.facebook.com/me/photos"
+              "https://graph.facebook.com/me/photos&access_token=${{ vars.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -85,7 +85,7 @@ jobs:
         id: photo_upload
         run: |
             json=$(curl -X POST \
-              -d "url=https://msen.jp/img/logo.png" \
+              -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=false" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -62,14 +62,16 @@ jobs:
 
             let date
             let photoUrl
+            let caption
             for (const item of items) {
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
                 date = item.pubDate;
                 photoUrl = item.enclosure.link;
+                caption = item.title + item.link + item.description;
               }
             }
 
-            return photoUrl
+            return JSON.stringify({photoUrl, caption});
           result-encoding: string
 
       - name: Get Facebook page access token
@@ -84,8 +86,11 @@ jobs:
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
+            photoUrl=$(echo ${{ steps.latest-data.outputs.result }} | jq -r '.photoUrl')
+            caption=$(echo ${{ steps.latest-data.outputs.result }} | jq -r '.caption')
             json=$(curl -X POST \
-              -d "url=${{ steps.latest-data.outputs.result }}" \
+              -d "url=${photoUrl}" \
+              -d "caption=${caption}" \
               -d "published=false" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -46,7 +46,9 @@ jobs:
         id: blog-posts-cache
         uses: actions/cache@v4
         with:
-          path: .cache
+          path: |
+            public
+            .cache
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -28,7 +28,7 @@ jobs:
             
             const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.BLOG_URL }}';
             
-            await fetch(rssUrl);
+            const response = await fetch(rssUrl);
             const data = await response.json();
             fs.writeFileSync('${{ env.RSS_FILENAME }}', JSON.stringify(data.items));
         

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -112,11 +112,16 @@ jobs:
               photo_id=$(echo $json | jq -r '.id')
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
-      # - name: Post feed to Facebook using the uploaded photos (Useful to post multiple photos)
+      # This is an example of posting a feed to Facebook using multiple uploaded photos.
+      # You only need to pass the ids of the uploaded photo into the 'attach_media' object.
+      # The attached_media object has index for each media file like attached_media[0], attached_media[1] and so on.  
+      # The message parameter is optional and is used to add a message to the post.
+      # - name: Post to Facebook using multiple uploaded photos
       #   if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
       #   run: |
       #       curl -i -X POST \
       #         -d "message=" \
-      #         -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
+      #         -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id1 }}"}" \
+      #         -d "attached_media[1]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id2 }}"}" \
       #         -d "access_token=${{ steps.token.outputs.page_access_token }}" \
       #         "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -65,26 +65,9 @@ jobs:
             return photoUrl
 
       - name: Post data to Facebook
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const { exec } = require('child_process');
-            exec('
+        run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              -d "access_token=${{ secrets.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}" \
-              "https://graph.facebook.com/me/photos"                
-            , (error, stdout, stderr) => {
-              if (error) {
-                console.error(`Error: ${error}`);
-                return;
-              }
-              if (stderr) {
-                console.error(`stderr: ${stderr}`);
-                return;
-              }
-              console.log(`stdout: ${stdout}`);
-            });
-
-  
+              -d "access_token=${{ vars.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}" \
+              "https://graph.facebook.com/me/photos"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -78,11 +78,14 @@ jobs:
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
           token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
+          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
+          echo "userid=${id_json}" >> $GITHUB_OUTPUT
+
 
       - name: Post data to Facebook
         run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos" \
+              "https://graph.facebook.com/v19.0/${{ steps.token.outputs.userid }}/photos" \
               -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -29,9 +29,9 @@ jobs:
             const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.BLOG_URL }}';
             
             fetch(rssUrl)
-            .then(response => {
+            .then((response) => {
               const data = response.json()
-              fs.writeFileSync(${{ env.RSS_FILENAME }}, JSON.stringify(data.items));
+              fs.writeFileSync('${{ env.RSS_FILENAME }}', JSON.stringify(data.items));
             })
             ;
         
@@ -49,7 +49,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const data = fs.readfilesync(${{ env.RSS_FILENAME }});
+            const data = fs.readfilesync('${{ env.RSS_FILENAME }}');
             const items = JSON.parse(data)
 
             let date

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,7 +80,7 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json
           echo $token
-          id_json=$(curl -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' -X GET "https://graph.facebook.com/me?fields=id")
+          id_json=$(curl -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' -X GET "https://graph.facebook.com/msenjp?fields=id")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -51,7 +51,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -73,7 +73,7 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook access token
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
@@ -81,7 +81,7 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
 
       - name: Post data to Facebook
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -1,0 +1,58 @@
+name: Release Facebook
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  release_facebook:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get data from RSS feed
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const https = require('https');
+            
+            const rssUrl = 'https://example.com/rss.xml';
+            const outputFile = 'rss.xml';
+            
+            https.get(rssUrl, (res) => {
+              let data = '';
+            
+              res.on('data', (chunk) => {
+                data += chunk;
+              });
+            
+              res.on('end', () => {
+                fs.writeFileSync(outputFile, data);
+
+                // POST PHOTO TO FACEBOOK
+                const { exec } = require('child_process');
+
+                exec('
+                curl -i -X POST \
+                  -d "url=https://www.facebook.com/images/fb_icon_325x325.png" \
+                  -d "published=false" \
+                  -d "access_token=<access_token>" \
+                  "https://graph.facebook.com/me/photos"                
+                , (error, stdout, stderr) => {
+                  if (error) {
+                    console.error(`Error: ${error}`);
+                    return;
+                  }
+                  if (stderr) {
+                    console.error(`stderr: ${stderr}`);
+                    return;
+                  }
+                  console.log(`stdout: ${stdout}`);
+                });
+
+              });
+            });

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Add mask to secret parameter
         run: |
-          user_token=${{ github.event.inputs.facebook_user_access_token || vars.secrets.FACEBOOK_USER_ACCESS_TOKEN }}
+          user_token=${{ github.event.inputs.facebook_user_access_token || secrets.FACEBOOK_USER_ACCESS_TOKEN }}
           echo "::add-mask::$user_token" 
           echo "FACEBOOK_USER_ACCESS_TOKEN=$user_token" >> $GITHUB_ENV
 
@@ -67,7 +67,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -91,7 +91,7 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook page access token
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
@@ -99,7 +99,7 @@ jobs:
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook (If published is 'true', the photo will be published on the page's timeline.)
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
             photoUrl=$(echo '${{ steps.latest-data.outputs.result }}' | jq -r '.photoUrl')

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -65,7 +65,7 @@ jobs:
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
                 date = item.pubDate;
                 photoUrl = item.enclosure.link;
-                caption = `${item.title}\n${item.link}\n${item.description}`;
+                caption = `${item.title}\n\n${item.link}\n\n${item.description}`;
               }
             }
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -3,10 +3,10 @@ name: Release Facebook
 on:
   workflow_dispatch:
     inputs:
-      url_param:
-        description: 'The param part of /${param}/photos URL'
+      page_id:
+        description: 'The pageId part of /${pageId}/photos URL'
         required: true
-        default: 'me'
+        default: 'msenjp'
   push:
     branches:
       - release
@@ -23,7 +23,7 @@ jobs:
       BLOG_URL: https://mseeeen.msen.jp/rss.xml
       RSS_FILENAME: rss.xml
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
-      URL_PARAM: ${{ github.event.inputs.url_param || 'msenjp' }}
+      PAGE_ID: ${{ github.event.inputs.page_id || 'msenjp' }}
       PAGE: https://www.facebook.com/msenjp/
 
     steps:
@@ -78,15 +78,9 @@ jobs:
       - name: Get Facebook access token
         id: token
         run: |
-          client=$(curl -X GET "https://www.facebook.com/dialog/oauth?client_id=${{ vars.FACEBOOK_APP_ID }}&redirect_uri=${{ env.PAGE }}")
-          echo $client
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
           token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
-          echo $json
-          echo $token
-          id_json=$(curl -H 'Authorization: Bearer ${token}' -X GET "https://graph.facebook.com/v19.0/msenjp?fields=id")
-          echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 
       - name: Post data to Facebook
@@ -94,5 +88,5 @@ jobs:
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              "https://graph.facebook.com/v19.0/${{ steps.token.outputs.userid }}/photos" \
+              "https://graph.facebook.com/v19.0/${{ env.PAGE_ID }}/photos" \
               -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -72,14 +72,6 @@ jobs:
             return photoUrl
           result-encoding: string
 
-      - name: Get Facebook access token
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
-        id: token
-        run: |
-          json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
-          token=$(echo $json | jq -r '.access_token')
-          echo "token=${token}" >> $GITHUB_OUTPUT
-
       - name: Post data to Facebook
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -23,7 +23,7 @@ jobs:
       BLOG_URL: https://mseeeen.msen.jp/rss.xml
       RSS_FILENAME: rss.xml
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
-      URL_PARAM: ${{ github.event.inputs.url_param || 'me' }}
+      URL_PARAM: ${{ github.event.inputs.url_param || 'msenjp' }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -69,7 +69,8 @@ jobs:
       - name: Get Facebook access token
         id: token
         run: |
-          token=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
+          json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
+          token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
 
       - name: Post data to Facebook

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -15,7 +15,6 @@ on:
       facebook_user_access_token:
         description: 'User access token to access Facebook'
         required: false
-        default: '1234567890'
   
   push:
     branches:
@@ -37,8 +36,7 @@ jobs:
       FACEBOOK_USER_ID: ${{ github.event.inputs.facebook_user_id || vars.FACEBOOK_USER_ID }}
 
     steps:
-
-      - name: Add mask to secret parameter
+      - name: Add mask to FACEBOOK_USER_ACCESS_TOKEN parameter
         run: |
           user_token=${{ github.event.inputs.facebook_user_access_token || secrets.FACEBOOK_USER_ACCESS_TOKEN }}
           echo "::add-mask::$user_token" 
@@ -68,7 +66,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -92,15 +90,15 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook page access token
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
-          json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
+          json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ env.FACEBOOK_USER_ACCESS_TOKEN }}")            
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook (If published is 'true', the photo will be published on the page's timeline.)
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
             photoUrl=$(echo '${{ steps.latest-data.outputs.result }}' | jq -r '.photoUrl')

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -2,6 +2,11 @@ name: Release Facebook
 
 on:
   workflow_dispatch:
+    inputs:
+      url_param:
+        description: 'The param part of /${param}/photos URL'
+        required: true
+        default: 'me'
   push:
     branches:
       - release
@@ -16,8 +21,9 @@ jobs:
 
     env:
       BLOG_URL: https://mseeeen.msen.jp/rss.xml
-      RSS_FILENAME: rss.xml 
+      RSS_FILENAME: rss.xml
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
+      URL_PARAM: ${{ github.event.inputs.url_param || 'me' }}
 
     steps:
       - name: Checkout repository
@@ -79,4 +85,4 @@ jobs:
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
               -d "access_token=${{ steps.token.outputs.token }}" \
-              "https://graph.facebook.com/v19.0/msenjp/photos"
+              "https://graph.facebook.com/v19.0/${{ env.URL_PARAM }}/photos"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - release
-      - 317-add-workflow-for-facebook-post
 
 jobs:
   release_facebook:
@@ -66,7 +65,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -90,7 +89,7 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook page access token
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ env.FACEBOOK_USER_ACCESS_TOKEN }}")            
@@ -99,7 +98,7 @@ jobs:
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook (If published is 'true', the photo will be published on the page's timeline.)
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
             photoUrl=$(echo '${{ steps.latest-data.outputs.result }}' | jq -r '.photoUrl')
@@ -113,11 +112,11 @@ jobs:
               photo_id=$(echo $json | jq -r '.id')
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
-#       - name: Post feed to Facebook using the uploaded photo
-# #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
-#         run: |
-#             curl -i -X POST \
-#               -d "message=" \
-#               -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
-#               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
-#               "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"
+      # - name: Post feed to Facebook using the uploaded photos (Useful to post multiple photos)
+      #   if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+      #   run: |
+      #       curl -i -X POST \
+      #         -d "message=" \
+      #         -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
+      #         -d "access_token=${{ steps.token.outputs.page_access_token }}" \
+      #         "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -20,8 +20,8 @@ jobs:
       name: Release
 
     env:
-      BLOG_URL: https://mseeeen.msen.jp/rss.xml
-      RSS_FILENAME: rss.xml
+      RSS_URL: https://mseeeen.msen.jp/rss.xml
+      RSS_FILENAME: rss.json
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
       PAGE_ID: ${{ github.event.inputs.page_id || 'msenjp' }}
       PAGE: https://www.facebook.com/msenjp/
@@ -36,7 +36,7 @@ jobs:
           script: |
             const fs = require('fs');
             
-            const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.BLOG_URL }}';
+            const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.RSS_URL }}';
             
             const response = await fetch(rssUrl);
             const data = await response.json();

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -6,6 +6,16 @@ on:
       page_id:
         description: 'Path parameter for /v19.0/{page-id}/photos endpoint'
         required: false
+      rss_url:
+        description: 'Url of the blog RSS'
+        required: false
+      facebook_user_id:
+        description: 'User ID to access Facebook'
+        required: false
+      facebook_user_access_token:
+        description: 'User access token to access Facebook'
+        required: false
+  
   push:
     branches:
       - release
@@ -19,12 +29,20 @@ jobs:
       name: Release
 
     env:
-      RSS_URL: ${{ vars.RSS_FEED_URL }}
+      RSS_URL: ${{ github.event.inputs.rss_url || vars.RSS_FEED_URL }}
       RSS_FILENAME: rss.json
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
-      PAGE_ID: ${{ vars.FACEBOOK_PAGE_ID }}
+      PAGE_ID: ${{ github.event.inputs.page_id || vars.FACEBOOK_PAGE_ID }}
+      FACEBOOK_USER_ID: ${{ github.event.inputs.facebook_user_id || vars.FACEBOOK_USER_ID }}
 
     steps:
+
+      - name: Add mask to secret parameter
+        run: |
+          user_token=${{ github.event.inputs.facebook_user_access_token || vars.secrets.FACEBOOK_USER_ACCESS_TOKEN }}
+          echo "::add-mask::$user_token" 
+          echo "FACEBOOK_USER_ACCESS_TOKEN=$user_token" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -76,7 +94,7 @@ jobs:
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
-          json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
+          json=$(curl -X GET "https://graph.facebook.com/${{ env.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -78,6 +78,8 @@ jobs:
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
           token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
+          echo $json
+          echo $token
           id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id&access_token=${token}")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -15,6 +15,7 @@ on:
       facebook_user_access_token:
         description: 'User access token to access Facebook'
         required: false
+        default: '1234567890'
   
   push:
     branches:

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -50,8 +50,8 @@ jobs:
             ${{ env.RSS_FILENAME }}
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
-      - if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
-        name: Get latest posts
+      - name: Get latest posts
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -75,14 +75,15 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook access token
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
           token=$(echo $json | jq -r '.access_token')
           echo "token=${token}" >> $GITHUB_OUTPUT
 
-
       - name: Post data to Facebook
+        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,11 +80,23 @@ jobs:
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
-      - name: Post data to Facebook
+      - name: Upload photo to Facebook
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        id: photo_upload
+        run: |
+            json=$(curl -X POST \
+              -d "url=${{ steps.latest-data.outputs.result }}" \
+              -d "published=true" \
+              -d "access_token=${{ steps.token.outputs.page_access_token }}" \
+              "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")
+              photo_id=$(echo $json | jq -r '.id')
+              echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
+    
+      - name: Post to Facebook
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
-              -d "url=https://msen.jp/img/logo.png" \
-              -d "published=true" \
+              -d "message=" \
+              -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
-              "https://graph.facebook.com/${{ env.PAGE_ID }}/photos" 
+              "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -85,7 +85,7 @@ jobs:
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
-      - name: Upload photo to Facebook
+      - name: Upload photo to Facebook (If published is true, the photo will be published on the page's timeline.)
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
@@ -94,17 +94,17 @@ jobs:
             json=$(curl -X POST \
               -d "url=${photoUrl}" \
               -d "caption=${caption}" \
-              -d "published=false" \
+              -d "published=true" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos")
               photo_id=$(echo $json | jq -r '.id')
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
-      - name: Post to Facebook
-#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
-        run: |
-            curl -i -X POST \
-              -d "message=" \
-              -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
-              -d "access_token=${{ steps.token.outputs.page_access_token }}" \
-              "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"
+#       - name: Post to Facebook
+# #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#         run: |
+#             curl -i -X POST \
+#               -d "message=" \
+#               -d "attached_media[0]={"media_fbid":"${{ steps.photo_upload.outputs.photo_id }}"}" \
+#               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
+#               "https://graph.facebook.com/${{ env.PAGE_ID }}/feed"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -56,10 +56,9 @@ jobs:
             let photoUrl
             for (const item of items) {
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
-                break;
+                date = item.pubDate;
+                photoUrl = item.enclosure.link;
               }
-              date = item.pubDate;
-              photoUrl = item.enclosure.link;
             }
 
             console.log(photoUrl)

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -11,6 +11,9 @@ jobs:
   release_facebook:
     runs-on: ubuntu-latest
 
+    environment:
+      name: Release
+
     env:
       BLOG_URL: https://mseeeen.msen.jp/rss.xml
       RSS_FILENAME: rss.xml 
@@ -56,7 +59,7 @@ jobs:
                 break;
               }
               date = item.pubDate;
-              photoUrl = item['media:content'][url];
+              photoUrl = item.enclosure.link;
             }
 
             return photoUrl

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       BLOG_URL: https://mseeeen.msen.jp/rss.xml
       RSS_FILENAME: rss.xml 
+      RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
 
     steps:
       - name: Checkout repository
@@ -25,15 +26,12 @@ jobs:
           script: |
             const fs = require('fs');
             
-            const rssUrl = '${{ env.BLOG_URL }}';
-            const outputFile = '${{ env.RSS_FILENAME }}';
+            const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.BLOG_URL }}';
             
             fetch(rssUrl)
-            .then(response => response.text())
-            .then(str => new window.DOMParser().parseFromString(str, "text/xml"))
-            .then(data => {
-              const items = data.querySelectorAll("item");
-              fs.writeFileSync(outputFile, JSON.stringify(items));
+            .then(response => {
+              const data = response.json()
+              fs.writeFileSync(${{ env.RSS_FILENAME }}, JSON.stringify(data.items));
             })
             ;
         
@@ -51,11 +49,12 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const str = fs.readfilesync(outputFile, data);
+            const data = fs.readfilesync(${{ env.RSS_FILENAME }});
+            const items = JSON.parse(data)
 
             let date
             let photoUrl
-            for (const item of JSON.parse(str)) {
+            for (const item of items) {
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
                 break;
               }

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -37,9 +37,9 @@ jobs:
             const fs = require('fs');
             
             const rssUrl = '${{ env.RSS_CONVERTER }}${{ env.RSS_URL }}';
-            
             const response = await fetch(rssUrl);
             const data = await response.json();
+
             fs.writeFileSync('${{ env.RSS_FILENAME }}', JSON.stringify(data.items));
         
       - name: Caching Hash

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,7 +80,7 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json
           echo $token
-          id_json=$(curl -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' -X GET "https://graph.facebook.com/msenjp?fields=id")
+          id_json=$(curl -H 'Authorization: Bearer ${token}' -X GET "https://graph.facebook.com/msenjp?fields=id")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -78,7 +78,7 @@ jobs:
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
-          token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
+          token=$(echo $json | jq -r '.access_token')
           echo "token=${token}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -69,8 +69,6 @@ jobs:
               }
             }
 
-            console.log(photoUrl)
-
             return photoUrl
           result-encoding: string
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -66,9 +66,18 @@ jobs:
             return photoUrl
           result-encoding: string
 
+      - name: Get Facebook access token
+        id: token
+        run: |
+          echo 'token=$(curl -X GET "https://graph.facebook.com/oauth/access_token
+            ?client_id=${{ vars.FACEBOOK_APP_ID }}
+            &client_secret=${{ secrets.FACEBOOK_APP_SECRET }}
+            &grant_type=client_credentials")' >> $GITHUB_OUTPUT
+
       - name: Post data to Facebook
         run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              "https://graph.facebook.com/me/photos&access_token=${{ vars.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}"
+              -d "access_token=${{ steps.token.outputs.token }}" \
+              "https://graph.facebook.com/me/photos"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -79,4 +79,4 @@ jobs:
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
               -d "access_token=${{ steps.token.outputs.token }}" \
-              "https://graph.facebook.com/msenjp/photos"
+              "https://graph.facebook.com/v19.0/msenjp/photos"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -1,6 +1,7 @@
 name: Release Facebook
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - release
@@ -8,6 +9,10 @@ on:
 jobs:
   release_facebook:
     runs-on: ubuntu-latest
+
+    env:
+      BLOG_URL: https://mseeeen.msen.jp/rss.xml
+      RSS_FILENAME: rss.xml 
 
     steps:
       - name: Checkout repository
@@ -18,41 +23,71 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const https = require('https');
             
-            const rssUrl = 'https://example.com/rss.xml';
-            const outputFile = 'rss.xml';
+            const rssUrl = '${{ env.BLOG_URL }}';
+            const outputFile = '${{ env.RSS_FILENAME }}';
             
-            https.get(rssUrl, (res) => {
-              let data = '';
-            
-              res.on('data', (chunk) => {
-                data += chunk;
-              });
-            
-              res.on('end', () => {
-                fs.writeFileSync(outputFile, data);
+            fetch(rssUrl)
+            .then(response => response.text())
+            .then(str => new window.DOMParser().parseFromString(str, "text/xml"))
+            .then(data => {
+              const items = data.querySelectorAll("item");
+              fs.writeFileSync(outputFile, JSON.stringify(items));
+            })
+            ;
+        
+      - name: Caching Hash
+        id: blog-posts-cache
+        uses: actions/cache@v4
+        with:
+          path: .cache
+          key: blog-post-${{ hashFiles(env.RSS_FILE_PATH) }}          
+      
+      - if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        name: Get latest posts
+        id: latest-data
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const str = fs.readfilesync(outputFile, data);
 
-                // POST PHOTO TO FACEBOOK
-                const { exec } = require('child_process');
+            let date
+            let photoUrl
+            for (const item of JSON.parse(str)) {
+              if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
+                break;
+              }
+              date = item.pubDate;
+              photoUrl = item['media:content'][url];
+            }
 
-                exec('
-                curl -i -X POST \
-                  -d "url=https://www.facebook.com/images/fb_icon_325x325.png" \
-                  -d "published=false" \
-                  -d "access_token=<access_token>" \
-                  "https://graph.facebook.com/me/photos"                
-                , (error, stdout, stderr) => {
-                  if (error) {
-                    console.error(`Error: ${error}`);
-                    return;
-                  }
-                  if (stderr) {
-                    console.error(`stderr: ${stderr}`);
-                    return;
-                  }
-                  console.log(`stdout: ${stdout}`);
-                });
+            return photoUrl
 
-              });
+      - name: Post data to Facebook
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const data = fs.readfilesync(outputFile, data);
+
+            const { exec } = require('child_process');
+            exec('
+            curl -i -X POST \
+              -d "url=${{ steps.latest-data.outputs.result }}" \
+              -d "published=false" \
+              -d "access_token=${{ secrets.FACEBOOK_APP_ID }}|${{ secrets.FACEBOOK_APP_SECRET }}" \
+              "https://graph.facebook.com/me/photos"                
+            , (error, stdout, stderr) => {
+              if (error) {
+                console.error(`Error: ${error}`);
+                return;
+              }
+              if (stderr) {
+                console.error(`stderr: ${stderr}`);
+                return;
+              }
+              console.log(`stdout: ${stdout}`);
             });
+
+  

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -79,4 +79,4 @@ jobs:
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
               -d "access_token=${{ steps.token.outputs.token }}" \
-              "https://graph.facebook.com/me/photos"
+              "https://graph.facebook.com/msenjp/photos"

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -84,7 +84,7 @@ jobs:
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
-              -d "url=${{ steps.latest-data.outputs.result }}" \
+              -d "url=https://msen.jp/img/logo.png" \
               -d "published=true" \
               -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos" 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -51,7 +51,7 @@ jobs:
           key: blog-post-${{ hashFiles(env.RSS_FILENAME) }}          
       
       - name: Get latest posts
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: latest-data
         uses: actions/github-script@v7
         with:
@@ -73,7 +73,7 @@ jobs:
           result-encoding: string
 
       - name: Get Facebook page access token
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: token
         run: |
           json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}")            
@@ -81,7 +81,7 @@ jobs:
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
       - name: Upload photo to Facebook
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
             json=$(curl -X POST \
@@ -93,7 +93,7 @@ jobs:
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
       - name: Post to Facebook
-        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
               -d "message=" \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -80,8 +80,7 @@ jobs:
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json
           echo $token
-          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id"\
-          -H 'Authorization: Bearer ${{ steps.token.outputs.token }}')
+          id_json=$(curl -H 'Authorization: Bearer ${{ steps.token.outputs.token }}' -X GET "https://graph.facebook.com/me?fields=id")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -67,7 +67,10 @@ jobs:
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
                 date = item.pubDate;
                 photoUrl = item.enclosure.link;
-                caption = item.title + item.link + item.description;
+                caption = `
+                ${item.title}
+                ${item.link}
+                ${item.description}`;
               }
             }
 
@@ -86,8 +89,8 @@ jobs:
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
-            photoUrl=$(echo ${{ steps.latest-data.outputs.result }} | jq -r '.photoUrl')
-            caption=$(echo ${{ steps.latest-data.outputs.result }} | jq -r '.caption')
+            photoUrl=$(echo '${{ steps.latest-data.outputs.result }}' | jq -r '.photoUrl')
+            caption=$(echo '${{ steps.latest-data.outputs.result }}' | jq -r '.caption')
             json=$(curl -X POST \
               -d "url=${photoUrl}" \
               -d "caption=${caption}" \

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -62,7 +62,10 @@ jobs:
               photoUrl = item.enclosure.link;
             }
 
+            console.log(photoUrl)
+
             return photoUrl
+          result-encoding: string
 
       - name: Post data to Facebook
         run: |

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -69,10 +69,7 @@ jobs:
       - name: Get Facebook access token
         id: token
         run: |
-          token=$(curl -X GET "https://graph.facebook.com/oauth/access_token
-            ?client_id=${{ vars.FACEBOOK_APP_ID }}
-            &client_secret=${{ secrets.FACEBOOK_APP_SECRET }}
-            &grant_type=client_credentials")
+          token=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
           echo "token=${token}" >> $GITHUB_OUTPUT
 
       - name: Post data to Facebook

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -78,7 +78,7 @@ jobs:
           json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
           token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
-          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
+          id_json=$(curl -X GET "https://graph.facebook.com/me?fields=id&access_token=${token}")
           echo "userid=${id_json}" >> $GITHUB_OUTPUT
 
 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -24,6 +24,7 @@ jobs:
       RSS_FILENAME: rss.xml
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
       URL_PARAM: ${{ github.event.inputs.url_param || 'msenjp' }}
+      PAGE: https://www.facebook.com/msenjp/
 
     steps:
       - name: Checkout repository
@@ -75,7 +76,9 @@ jobs:
       - name: Get Facebook access token
         id: token
         run: |
-          json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&grant_type=client_credentials")
+          client=$(curl -X GET "https://www.facebook.com/dialog/oauth?client_id=${{ vars.FACEBOOK_APP_ID }}&redirect_uri=${{ env.PAGE }}")
+          echo $client
+          json=$(curl -X GET "https://graph.facebook.com/oauth/access_token?client_id=${{ vars.FACEBOOK_APP_ID }}&client_secret=${{ secrets.FACEBOOK_APP_SECRET }}&redirect_uri=${{ env.PAGE }}&grant_type=client_credentials")
           token=$(echo $json | grep -o '"access_token":"[^"]*' | grep -o '[^"]*$')
           echo "token=${token}" >> $GITHUB_OUTPUT
           echo $json

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -4,9 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       page_id:
-        description: 'The pageId part of /${pageId}/photos URL'
-        required: true
-        default: 'msenjp'
+        description: 'Path parameter for /v19.0/{page-id}/photos endpoint'
+        required: false
   push:
     branches:
       - release
@@ -20,11 +19,10 @@ jobs:
       name: Release
 
     env:
-      RSS_URL: https://mseeeen.msen.jp/rss.xml
+      RSS_URL: ${{ vars.RSS_FEED_URL }}
       RSS_FILENAME: rss.json
       RSS_CONVERTER: https://api.rss2json.com/v1/api.json?rss_url=
-      PAGE_ID: ${{ github.event.inputs.page_id || 'msenjp' }}
-      PAGE: https://www.facebook.com/msenjp/
+      PAGE_ID: ${{ github.event.inputs.page_id || vars.FACEBOOK_PAGE_ID }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -72,11 +72,19 @@ jobs:
             return photoUrl
           result-encoding: string
 
+      - name: Get Facebook page access token
+#        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
+        id: token
+        run: |
+          json=$(curl -X GET "https://graph.facebook.com/${{ vars.FACEBOOK_USER_ID }}/accounts?access_token=${{ secrets.FACEBOOK_USER_ACCESS_TOKEN }}"            
+          token=$(echo $json | jq -r '.data[].access_token')
+          echo "page_access_token=${token}" >> $GITHUB_OUTPUT
+
       - name: Post data to Facebook
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         run: |
             curl -i -X POST \
               -d "url=${{ steps.latest-data.outputs.result }}" \
               -d "published=true" \
-              -d "access_token=${{ secrets.FACEBOOK_PAGE_ACCESS_TOKEN }}" \
+              -d "access_token=${{ steps.token.outputs.page_access_token }}" \
               "https://graph.facebook.com/${{ env.PAGE_ID }}/photos" 

--- a/.github/workflows/release-facebook.yml
+++ b/.github/workflows/release-facebook.yml
@@ -67,10 +67,7 @@ jobs:
               if (!date || new Date(date).getTime() < new Date(item.pubDate).getTime()) {
                 date = item.pubDate;
                 photoUrl = item.enclosure.link;
-                caption = `
-                ${item.title}
-                ${item.link}
-                ${item.description}`;
+                caption = `${item.title}\n${item.link}\n${item.description}`;
               }
             }
 
@@ -85,7 +82,7 @@ jobs:
           token=$(echo $json | jq -r '.data[].access_token')
           echo "page_access_token=${token}" >> $GITHUB_OUTPUT
 
-      - name: Upload photo to Facebook (If published is true, the photo will be published on the page's timeline.)
+      - name: Upload photo to Facebook (If published is 'true', the photo will be published on the page's timeline.)
 #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
         id: photo_upload
         run: |
@@ -100,7 +97,7 @@ jobs:
               photo_id=$(echo $json | jq -r '.id')
               echo "photo_id=${photo_id}" >> $GITHUB_OUTPUT
     
-#       - name: Post to Facebook
+#       - name: Post feed to Facebook using the uploaded photo
 # #        if: ${{ steps.blog-posts-cache.outputs.cache-hit != 'true' }}
 #         run: |
 #             curl -i -X POST \


### PR DESCRIPTION
- close #317 

This PR adds a workflow to post the blog posts in Facebook page.

Currently I added a template based on the Facebook API documentation and using a code suggested by GitHub Copilot.
As other workflow, I am using `actions/github-script`. However, I am not sure if this is the best approach since the scripts seems to be out of the scope of the code editor.