### PR TITLE
タイトルに VSCode を含めるように修正

### DIFF
--- a/Ryotaro49/2024/using-github-codespaces-on-ipad/index.md
+++ b/Ryotaro49/2024/using-github-codespaces-on-ipad/index.md
@@ -1,5 +1,5 @@
 ---
-title: "iPad で GitHub Codespaces を使ってみた"
+title: "iPad で VSCode を使いたい！GitHub Codespaces の利用方法"
 date: 2024-11-30
 author: Ryotaro49
 tags: [iPad, GitHub Codespaces, VS Code]


### PR DESCRIPTION
SEO 対策でタイトルを変更しました。
iPad VSCode で検索をかけた時に見つけられるといいなと思っています。